### PR TITLE
representatives feature flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,16 @@
 # verenigingsloket-download-service
  Micro-service for dowloading associations
+
+## Configuration
+
+The service can be configured using the following environment variables:
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `SHARE_FOLDER` | Path to the shared folder for file storage | `/share` |
+| `FILES_GRAPH` | Graph URI for file storage | `http://mu.semte.ch/graphs/organizations` |
+| `SOURCE_GRAPH` | Graph URI for source data | `http://mu.semte.ch/graphs/organizations` |
+| `SERVICE_NAME` | Service identifier URI | `http://data.lblod.info/services/id/verenigingsloket-download-service` |
+| `CRON_PATTERN_SPREADSHEET_JOB` | Cron pattern for scheduled spreadsheet generation | `0 0 * * *` (daily at midnight) |
+| `CHUNK_SIZE` | Number of associations to process per batch | `100` |
+| `FEATURE_INCLUDE_REPRESENTATIVES` | Include representatives tab in export | `false` |

--- a/app.js
+++ b/app.js
@@ -1,7 +1,8 @@
 import { app, uuid } from 'mu'
 import { SHARE_FOLDER,
          SOURCE_GRAPH,
-         CRON_PATTERN_SPREADSHEET_JOB
+         CRON_PATTERN_SPREADSHEET_JOB,
+         FEATURE_INCLUDE_REPRESENTATIVES
        } from './env-config';
 import {
   getAllAssociations,
@@ -37,15 +38,19 @@ async function createSpreadSheet (associationIds) {
   let allRepresentatives = []
 
   for (const chunk of associationIdChunks) {
-    const [associations, locations, representatives] = await Promise.all([
+    const queries = [
       queryAssociations(chunk, graph),
       queryLocations(chunk, graph),
-      queryRepresentatives(chunk, graph)
-    ])
+    ]
+    if (FEATURE_INCLUDE_REPRESENTATIVES) {
+      queries.push(queryRepresentatives(chunk, graph))
+    }
+
+    const [associations, locations, representatives] = await Promise.all(queries)
 
     if (associations) allAssociations.push(...associations)
     if (locations) allLocations.push(...locations)
-    if (representatives) allRepresentatives.push(...representatives)
+    if (FEATURE_INCLUDE_REPRESENTATIVES && representatives) allRepresentatives.push(...representatives)
   }
 
   if (allAssociations.length === 0) {

--- a/env-config.js
+++ b/env-config.js
@@ -3,3 +3,4 @@ export const FILES_GRAPH = process.env.FILES_GRAPH || 'http://mu.semte.ch/graphs
 export const SOURCE_GRAPH = process.env.SOURCE_GRAPH || 'http://mu.semte.ch/graphs/organizations';
 export const SERVICE_NAME = process.env.SERVICE_NAME || 'http://data.lblod.info/services/id/verenigingsloket-download-service';
 export const CRON_PATTERN_SPREADSHEET_JOB = process.env.CRON_PATTERN_SPREADSHEET_JOB || '0 0 * * *';
+export const FEATURE_INCLUDE_REPRESENTATIVES = process.env.FEATURE_INCLUDE_REPRESENTATIVES === 'true';


### PR DESCRIPTION
I've added a feature flag which now defaults to off - so it can be enabled easily should requirements change again. 

Trigger xlsx creation for one assoction (uuid) (or multiple comma separated values)
```
drc exec download curl -X POST http://localhost/jobs\?associationIds\=b1f2566b-4101-5d2e-8ce5-dbb1785c4f39
```
re-enable representatives tab (default off)
```
  download: 
    environment:
      FEATURE_INCLUDE_REPRESENTATIVES: 'true'
```